### PR TITLE
Add authentication mixins

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,26 @@
+from knox.auth import TokenAuthentication
+from rest_framework import exceptions
+from .models import Member
+from rest_framework.authentication import get_authorization_header
+from django.utils.translation import ugettext_lazy as _
+
+
+class LabsTokenAuthentication(TokenAuthentication):
+    def authenticate(self, request):
+        auth = get_authorization_header(request).split()
+        prefix = "Token".encode()
+        if not auth or auth[0].lower() != prefix.lower():
+            return None
+        if len(auth) == 1:
+            msg = _('Invalid token header. No credentials provided.')
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = _('Invalid token header. '
+                    'Token string should not contain spaces.')
+            raise exceptions.AuthenticationFailed(msg)
+        (user, auth_token) = super().authenticate(request)
+        if Member.objects.filter(user=user).exists():
+            return (user, auth_token)
+        else:
+            raise exceptions.AuthenticationFailed(
+                _('Authentication Failed. User is not a Penn Labs member'))

--- a/api/views.py
+++ b/api/views.py
@@ -2,9 +2,11 @@ from rest_framework import viewsets, generics
 from .models import Member, Team, Role, Update, Event
 from .serializers import MemberSerializer, TeamSerializer, RoleSerializer, UpdateSerializer, EventSerializer
 from knox.auth import TokenAuthentication
+from .auth import LabsTokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.decorators import list_route
+from rest_framework import exceptions
 
 
 class MemberViewSet(viewsets.ModelViewSet):
@@ -48,9 +50,16 @@ class EventViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
 
 
-class ProtectedViewSet(generics.GenericAPIView):
+class PennAuthMixin(generics.GenericAPIView):
     authentication_classes = (TokenAuthentication,)
     permission_classes = (IsAuthenticated,)
 
+
+class LabsAuthMixin(generics.GenericAPIView):
+    authentication_classes = (LabsTokenAuthentication,)
+    permission_classes = (IsAuthenticated,)
+
+
+class ProtectedViewSet(LabsAuthMixin, generics.GenericAPIView):
     def get(self, request, format=None):
         return Response({"secret_information": "this is a protected route"})


### PR DESCRIPTION
This PR adds authentication mixins to easily validate user credentials.
`PennAuthMixin` checks if the request passes a valid knox token
`LabsAuthMixin` checks if the request passes a valid knox token and that the logged in user is a member of Penn Labs.
`api/protected` has also been updated to provide an example of how to use them. \
\
\
:warning:  Do not merge this PR immediately after PR #11.  This branch needs to be rebased, then merged. :warning: 