### PR TITLE
Add url shortener

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shortener"]
+	path = shortener
+	url = https://github.com/pennlabs/shortener.git

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
-from api.views import (MemberViewSet, AlumniViewSet, TeamViewSet, RoleViewSet, 
-    UpdateViewSet, EventViewSet, ProtectedViewSet)
-
+from shortener.views import index
+from api.views import (ShortURLViewSet, MemberViewSet, AlumniViewSet, TeamViewSet,
+    RoleViewSet, UpdateViewSet, EventViewSet, ProtectedViewSet)
 
 urlpatterns = [
+    path("urls/get/<slug:short>/", index, name='index'),
+    path("urls/create/", ShortURLViewSet.as_view()),
     path("members/", MemberViewSet.as_view({'get': 'list'})),
     path("members/<slug:url>", MemberViewSet.as_view({'get': 'single_member'})),
     path("alumni/", AlumniViewSet.as_view({'get': 'list'})),

--- a/api/views.py
+++ b/api/views.py
@@ -1,12 +1,28 @@
+from django.core.validators import URLValidator
+from django.core.exceptions import ValidationError
+from django.http import HttpResponse
 from rest_framework import viewsets, generics, exceptions
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.decorators import list_route
 from knox.auth import TokenAuthentication
+from shortener.models import shorten
 from api.models import Member, Team, Role, Update, Event
 from api.serializers import (MemberSerializer, TeamSerializer, RoleSerializer,
     UpdateSerializer, EventSerializer)
 from api.auth import LabsTokenAuthentication
+
+
+class ShortURLViewSet(generics.GenericAPIView):
+    def post(self, request):
+        print(request.data.get('url'))
+        try:
+            url = request.data.get('url', '')
+            URLValidator()(url)
+            short = shorten(url)
+            return Response({'short': short.short_id, "long": url})
+        except ValidationError:
+            return HttpResponse(status=400)
 
 
 class MemberViewSet(viewsets.ModelViewSet):

--- a/pennlabs/settings.py
+++ b/pennlabs/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'shortener.apps.ShortenerConfig',
     'knox',
     'api',
     'accounts'


### PR DESCRIPTION
Adds a URL shortener. Uses the endpoints 
1. `api/urls/create` to create a short url from a `url` body parameter
2. `api/urls/get/<slug>` to redirect the user to the long url from the slug.