### PR TITLE
Cleanup/misc

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,11 +1,10 @@
 from django.urls import path, include
 from knox.views import LogoutView, LogoutAllView
-from accounts.views import RegistrationView, LoginView, UserView
+from accounts.views import RegistrationView, LoginView
 
 urlpatterns = [
     path("register/", RegistrationView.as_view()),
     path("login/", LoginView.as_view()),
     path("logout/", LogoutView.as_view()),
     path("logoutall/", LogoutAllView.as_view()),
-    path("users/", UserView.as_view({'get': 'list'}))
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -36,9 +36,3 @@ class LoginView(generics.GenericAPIView):
             "user": UserSerializer(user, context=self.get_serializer_context()).data,
             "token": AuthToken.objects.create(user)
         })
-
-
-class UserView(viewsets.ModelViewSet):
-    queryset = User.objects.all()
-    serializer_class = UserSerializer
-    http_method_names = ['get']

--- a/clubs/admin.py
+++ b/clubs/admin.py
@@ -4,8 +4,6 @@ from clubs.models import Club, Event
 
 class EventAdmin(admin.ModelAdmin):
     list_display = ('name', 'club', 'time')
-    list_filter = ()
-    raw_id_fields = ()
 
 
 admin.site.register(Club)

--- a/clubs/admin.py
+++ b/clubs/admin.py
@@ -2,5 +2,11 @@ from django.contrib import admin
 from clubs.models import Club, Event
 
 
+class EventAdmin(admin.ModelAdmin):
+    list_display = ('name', 'club', 'time')
+    list_filter = ()
+    raw_id_fields = ()
+
+
 admin.site.register(Club)
-admin.site.register(Event)
+admin.site.register(Event, EventAdmin)

--- a/clubs/models.py
+++ b/clubs/models.py
@@ -22,4 +22,4 @@ class Event(models.Model):
     description = models.TextField()
 
     def __str__(self):
-        return self.club.name + ": " + self.name + " (" + self.time.strftime('%Y-%m-%d') + ")"
+        return self.name

--- a/org/admin.py
+++ b/org/admin.py
@@ -3,7 +3,6 @@ from org.models import Member, Team, Role
 from accounts.models import User
 
 
-admin.site.site_header = "Platform Admin"
 admin.site.register(User)
 admin.site.register(Member)
 admin.site.register(Team)

--- a/pennlabs/urls.py
+++ b/pennlabs/urls.py
@@ -4,6 +4,8 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from rest_framework.documentation import include_docs_urls
 
+admin.site.site_header = "Platform Admin"
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('accounts/', include('accounts.urls')),


### PR DESCRIPTION
This PR cleans up a couple of things:
* Removes an unnecessary `accounts/users` endpoint
* Moves the admin header definition to `pennlabs.url`
* Adds a ModelAdmin to `clubs.Event` 