### PR TITLE
Cleanup/misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The Penn Lab's Platform API for accessing Users, Products, Members, Updates and 
 ## Usage
 0. Configure environment variables (e.g. `.env`) containing:
 ```
-DB_PASSWORD=password
+DATABASE_URL=mysql://USER:PASSWORD@HOST:PORT/NAME
 SECRET_KEY=secret
-PLATFORM_ENV=(debug/prod)
+DJANGO_SETTINGS_MODULE=pennlabs.settings.production
 ```
 1. Install requirements using `pip install -r requirements.txt`.
 2. Run server using `python manage.py runserver`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ DJANGO_SETTINGS_MODULE=pennlabs.settings.production
 2. Run server using `python manage.py runserver`.
 
 ## Documentation
-Routes are defined in `/pennlabs/urls.py` and subsequent app folders in the form of `*/urls.py`. Account/authorization related scripts are located in `accounts/` and Penn Labs related routes are located in `org/`.
+Routes are defined in `/pennlabs/urls.py` and subsequent app folders in the form of `*/urls.py`. Account/authorization related scripts are located in `accounts/` and Penn Labs related scripts are located in `org/`.
+
+Documentation about individual endpoints is available through the `documentation/` route when the Django app is running.
 
 ## Current Maintainers
 - [Arun Kirubarajan](https://github.com/kirubarajan)

--- a/org/models.py
+++ b/org/models.py
@@ -22,7 +22,7 @@ class Role(models.Model):
 
 
 class Member(models.Model):
-    user = models.OneToOneField(User, on_delete=models.DO_NOTHING)
+    user = models.OneToOneField(User, on_delete=models.DO_NOTHING, null=True, blank=True)
     bio = models.TextField()
     location = models.CharField(max_length=255)
     teams = models.ManyToManyField(Team)

--- a/pennlabs/settings/base.py
+++ b/pennlabs/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
+import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -86,10 +87,7 @@ WSGI_APPLICATION = 'pennlabs.wsgi.application'
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
+    'default': dj_database_url.config(default="sqlite:///" + os.path.join(BASE_DIR, 'db.sqlite3'))
 }
 
 # Password validation

--- a/pennlabs/settings/production.py
+++ b/pennlabs/settings/production.py
@@ -4,18 +4,6 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 
 DEBUG = False
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'platform',
-        'USER': 'platform',
-        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': 'sql.pennlabs.org',
-        'PORT': 3306,
-        'OPTIONS': {'charset': 'utf8mb4'},
-    }
-}
-
 # Disable Django's own staticfiles handling in favour of WhiteNoise, for
 # greater consistency between gunicorn and `./manage.py runserver`. See:
 # http://whitenoise.evans.io/en/stable/django.html#using-whitenoise-in-development

--- a/pennlabs/wsgi.py
+++ b/pennlabs/wsgi.py
@@ -8,13 +8,9 @@ https://docs.djangoproject.com/en/2.1/howto/deployment/wsgi/
 """
 
 import os
-from whitenoise import WhiteNoise
 from django.core.wsgi import get_wsgi_application
 
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pennlabs.settings.production')
 
 application = get_wsgi_application()
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-application = WhiteNoise(application, root=os.path.join(BASE_DIR, "static"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asn1crypto==0.24.0
 cffi==1.11.5
 coreapi==2.3.3
 cryptography==2.3.1
+dj-database-url==0.5.0
 Django==2.0.8
 django-rest-knox==3.1.5
 djangorestframework==3.8.2


### PR DESCRIPTION
This PR:
* Adds the ability to define a production database through the `DATABASE_URL` environment variable
* Removes an unnecessary whitenoise wsgi wrapper (The proper whitenoise configuration is definied in `pennlabs.settings.production` 