### PR TITLE
Misc/cleanup

### DIFF
--- a/org/serializers.py
+++ b/org/serializers.py
@@ -8,7 +8,7 @@ from org.models import Member, Team, Role
 class ShortUrlSerializer(serializers.ModelSerializer):
     class Meta:
         model = Url
-        fields = ('short_id', 'long_url')
+        fields = ('short_id',)
 
 
 class TeamSerializer(serializers.ModelSerializer):

--- a/org/urls.py
+++ b/org/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path("urls/get/<slug:short>/", index, name='index'),
     path("urls/create/", ShortUrlViewSet.as_view()),
     path("members/", MemberViewSet.as_view({'get': 'list'})),
-    path("members/<slug:url>", MemberViewSet.as_view({'get': 'single_member'})),
+    path("members/get/<slug:url>/", MemberViewSet.as_view({'get': 'single_member'})),
     path("alumni/", AlumniViewSet.as_view({'get': 'list'})),
     path("teams/", TeamViewSet.as_view({'get': 'list'})),
     path("roles/", RoleViewSet.as_view({'get': 'list'})),

--- a/org/views.py
+++ b/org/views.py
@@ -1,6 +1,7 @@
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets, generics
 from rest_framework.response import Response
 from rest_framework.decorators import list_route
@@ -39,8 +40,8 @@ class MemberViewSet(viewsets.ModelViewSet):
         """
         Return a single member of Penn Labs using their unique url
         """
-        serializer = self.get_serializer(Member.objects.all().filter(alumnus=False, url=url).first(), many=False)
-        return Response(serializer.data)
+        obj = get_object_or_404(Member, alumnus=False, url=url)
+        return Response(self.get_serializer(obj).data)
 
 
 class AlumniViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
This PR
* Removes an unnecessary `long_url` field from ShortUrlSerializer
* Uses `get_object_or_404` for getting Labs members
* Moves the get single labs member endpoint to `org/members/get/<slug>`