### PR TITLE
Update Member Views

### DIFF
--- a/org/urls.py
+++ b/org/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path("urls/get/<slug:short>/", index, name='index'),
     path("urls/create/", ShortUrlViewSet.as_view()),
     path("members/", MemberViewSet.as_view({'get': 'list'})),
-    path("members/get/<slug:url>/", MemberViewSet.as_view({'get': 'single_member'})),
+    path("members/get/<slug:url>/", MemberViewSet.as_view({'get': 'retrieve'})),
     path("alumni/", AlumniViewSet.as_view({'get': 'list'})),
     path("teams/", TeamViewSet.as_view({'get': 'list'})),
     path("roles/", RoleViewSet.as_view({'get': 'list'})),

--- a/org/views.py
+++ b/org/views.py
@@ -1,10 +1,8 @@
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404
 from rest_framework import viewsets, generics
 from rest_framework.response import Response
-from rest_framework.decorators import list_route
 from shortener.models import shorten
 from accounts.auth import PennAuthMixin, LabsAuthMixin
 from org.models import Member, Team, Role

--- a/org/views.py
+++ b/org/views.py
@@ -29,19 +29,16 @@ class ShortUrlViewSet(generics.GenericAPIView):
 
 class MemberViewSet(viewsets.ModelViewSet):
     """
+    retrieve:
+    Return a single member of Penn Labs using their unique url.
+
+    list:
     Return a list of current Penn Labs members.
     """
     queryset = Member.objects.all().filter(alumnus=False)
     serializer_class = MemberSerializer
     http_method_names = ['get']
-
-    @list_route()
-    def single_member(self, request, url=None):
-        """
-        Return a single member of Penn Labs using their unique url
-        """
-        obj = get_object_or_404(Member, alumnus=False, url=url)
-        return Response(self.get_serializer(obj).data)
+    lookup_field = 'url'
 
 
 class AlumniViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
This PR adjusts the `/org/members/get/<slug>` endpoint to use a default Django Rest Framework view instead of using our own method.
The is no actual change in the usage of the endpoint.