### PR TITLE
Fix Login

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -12,13 +12,10 @@ class LoginView(generics.GenericAPIView):
     """
     Log in a user.
     """
-    def login_redirect(self):
-        return redirect('https://auth.pennlabs.org/login/')
-
     def get(self, request):
         # Validate API Key
         if not HasAPIKey.has_permission(self, request, self):
-            return self.login_redirect()
+            return redirect('https://auth.pennlabs.org/login/?next=' + request.GET.get('next', ''))
 
         # API is valid, login user
         pennkey = request.META.get('HTTP_EPPN', '').lower().split('@')[0]
@@ -29,7 +26,7 @@ class LoginView(generics.GenericAPIView):
         user = auth.authenticate(remote_user=pennkey, shibboleth_attributes=shibboleth_attributes)
         if user:
             auth.login(request, user)
-            return redirect('/accounts/authorize/')
+            return redirect('https://platform.pennlabs.org' + request.GET.get('next', ''))
         capture_message("Invalid user returned from shibboleth")
         return HttpResponseServerError()
 

--- a/tests/accounts/test_views.py
+++ b/tests/accounts/test_views.py
@@ -1,4 +1,6 @@
 from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from oauth2_provider.models import Application
 from rest_framework_api_key.models import APIKey
 
 
@@ -8,19 +10,24 @@ class LoginViewTestCase(TestCase):
         self.secret_key = 'super_secret'
         self.api_key = APIKey.objects.create(secret_key=self.secret_key)
 
+    def test_next_variable(self):
+        response = self.client.get('/accounts/login/?next=/accounts/authorize/%3Fclient_id%3Done%26state%3Dabc')
+        sample_response = 'https://auth.pennlabs.org/login/?next=/accounts/authorize/?client_id=one&state=abc'
+        self.assertRedirects(response, sample_response, fetch_redirect_response=False)
+
     def test_no_api_key(self):
         response = self.client.get('/accounts/login/')
-        self.assertRedirects(response, 'https://auth.pennlabs.org/login/', fetch_redirect_response=False)
+        self.assertRedirects(response, 'https://auth.pennlabs.org/login/?next=', fetch_redirect_response=False)
 
     def test_invalid_api_key(self):
         headers = {'HTTP_API_TOKEN': 'invalid_token'}
         response = self.client.get('/accounts/login/', headers)
-        self.assertRedirects(response, 'https://auth.pennlabs.org/login/', fetch_redirect_response=False)
+        self.assertRedirects(response, 'https://auth.pennlabs.org/login/?next=', fetch_redirect_response=False)
 
     def test_invalid_api_key_secret(self):
         headers = {'HTTP_API_TOKEN': self.api_key.token, 'HTTP_API_SECRET_KEY': 'invalid_secret'}
         response = self.client.get('/accounts/login/', headers)
-        self.assertRedirects(response, 'https://auth.pennlabs.org/login/', fetch_redirect_response=False)
+        self.assertRedirects(response, 'https://auth.pennlabs.org/login/?next=', fetch_redirect_response=False)
 
     def test_valid_api_key_invalid_shibboleth(self):
         headers = {'HTTP_API_TOKEN': self.api_key.token, 'HTTP_API_SECRET_KEY': self.secret_key}
@@ -30,5 +37,8 @@ class LoginViewTestCase(TestCase):
     def test_valid_api_key_valid_shibboleth(self):
         headers = {'HTTP_API_TOKEN': self.api_key.token, 'HTTP_API_SECRET_KEY': self.secret_key, 'HTTP_EPPN': 'test',
                    'HTTP_GIVENNAME': 'test', 'HTTP_SN': 'user', 'HTTP_MAIL': 'test@student.edu'}
-        response = self.client.get('/accounts/login/', follow=True, **headers)
-        self.assertRedirects(response, '/accounts/authorize/', target_status_code=400)
+        params = '/accounts/authorize/%3Fclient_id%3Dabc123%26response_type%3Dcode%26state%3Dabc'
+        response = self.client.get('/accounts/login/?next=' + params, **headers)
+        base_url = 'https://platform.pennlabs.org/accounts/authorize/'
+        sample_response = base_url + '?client_id=abc123&response_type=code&state=abc'
+        self.assertRedirects(response, sample_response, fetch_redirect_response=False)


### PR DESCRIPTION
This PR fixes our login route to handle GET parameters. This means when a client tries to get an OAuth2 token, they will be redirected as needed if they are not logged in.