### PR TITLE
Shibboleth-authenticated admin login

### DIFF
--- a/Platform/settings/base.py
+++ b/Platform/settings/base.py
@@ -151,6 +151,10 @@ OAUTH2_PROVIDER = {
 
 AUTH_USER_MODEL = "accounts.User"
 
+# Enable admin login through shibboleth
+SHIB_ADMIN = True
+
+# Other settings
 EMAIL_WEB_SERVICE_URL = os.environ.get("EMAIL_WEB_SERVICE_URL", "http://127.0.0.1")
 EMAIL_WEB_SERVICE_USERNAME = os.environ.get("EMAIL_WEB_SERVICE_USERNAME", "")
 EMAIL_WEB_SERVICE_PASSWORD = os.environ.get("EMAIL_WEB_SERVICE_PASSWORD", "")

--- a/Platform/settings/development.py
+++ b/Platform/settings/development.py
@@ -7,3 +7,6 @@ INSTALLED_APPS += ["django_extensions", "debug_toolbar"]
 
 MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
 INTERNAL_IPS = ["127.0.0.1"]
+
+# Disable admin login through shibboleth
+SHIB_ADMIN = False

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -60,7 +60,7 @@ class LabsAdminSite(admin.AdminSite):
 
 if settings.SHIB_ADMIN:
     """
-    Replace the default admin site with a custom one to log in users through platform.
+    Replace the default admin site with a custom one to log in users through shibboleth.
     Also copy all registered models from the default admin site
     """
     labs_admin = LabsAdminSite()

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,5 +1,8 @@
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.models import Permission
+from django.shortcuts import redirect
+from django.urls import reverse
 
 from accounts.models import Student, User
 
@@ -41,3 +44,25 @@ class UserAdmin(admin.ModelAdmin):
 admin.site.register(Permission)
 admin.site.register(Student, StudentAdmin)
 admin.site.register(User, UserAdmin)
+
+
+class LabsAdminSite(admin.AdminSite):
+    """
+    Custom admin site that redirects users to log in through shibboleth
+    instead of logging in with a username and password
+    """
+
+    def login(self, request, extra_context=None):
+        if not request.user.is_authenticated:
+            return redirect(reverse("accounts:login") + "?next=" + request.GET.get("next"))
+        return super().login(request, extra_context)
+
+
+if settings.SHIB_ADMIN:
+    """
+    Replace the default admin site with a custom one to log in users through platform.
+    Also copy all registered models from the default admin site
+    """
+    labs_admin = LabsAdminSite()
+    labs_admin._registry = admin.site._registry
+    admin.site = labs_admin

--- a/tests/accounts/test_admin.py
+++ b/tests/accounts/test_admin.py
@@ -1,5 +1,10 @@
+import os
+from unittest import skipIf
+
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 
 from accounts.admin import StudentAdmin
 from accounts.models import Student, User
@@ -21,3 +26,19 @@ class StudentAdminTestCase(TestCase):
 
     def test_last_name(self):
         self.assertEqual(self.sa.last_name(self.student), self.user.last_name)
+
+
+class LabsAdminTestCase(TestCase):
+    check = os.environ.get("DJANGO_SETTINGS_MODULE", "") == "Platform.settings.development"
+    @skipIf(check, "This test doesn't matter in development")
+    def test_admin_not_logged_in(self):
+        response = self.client.get(reverse("admin:login") + "?next=/admin/")
+        redirect = reverse("accounts:login") + "?next=/admin/"
+        self.assertRedirects(response, redirect, fetch_redirect_response=False)
+
+    def test_admin_logged_in(self):
+        get_user_model().objects.create_user(username="user", password="password", is_staff=True)
+        self.client.login(username="user", password="password")
+        response = self.client.get(reverse("admin:login") + "?next=/admin/")
+        redirect = "/admin/"
+        self.assertRedirects(response, redirect, fetch_redirect_response=False)

--- a/tests/accounts/test_admin.py
+++ b/tests/accounts/test_admin.py
@@ -30,6 +30,7 @@ class StudentAdminTestCase(TestCase):
 
 class LabsAdminTestCase(TestCase):
     check = os.environ.get("DJANGO_SETTINGS_MODULE", "") == "Platform.settings.development"
+
     @skipIf(check, "This test doesn't matter in development")
     def test_admin_not_logged_in(self):
         response = self.client.get(reverse("admin:login") + "?next=/admin/")

--- a/tests/accounts/test_admin.py
+++ b/tests/accounts/test_admin.py
@@ -38,7 +38,9 @@ class LabsAdminTestCase(TestCase):
         self.assertRedirects(response, redirect, fetch_redirect_response=False)
 
     def test_admin_logged_in(self):
-        get_user_model().objects.create_user(username="user", password="password", is_staff=True)
+        get_user_model().objects.create_user(
+            pennid=1, username="user", password="password", is_staff=True
+        )
         self.client.login(username="user", password="password")
         response = self.client.get(reverse("admin:login") + "?next=/admin/")
         redirect = "/admin/"


### PR DESCRIPTION
This PR adds a custom admin site that redirects the user to log in through shibboleth instead of using a username and password.