### PR TITLE
Sync product admin from GitHub

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -5,6 +5,7 @@ from accounts.views import (
     LabsProtectedViewSet,
     LoginView,
     LogoutView,
+    ProductAdminView,
     ProtectedViewSet,
     UserSearchView,
     UUIDIntrospectTokenView,
@@ -21,6 +22,7 @@ urlpatterns = [
     path("authorize/", AuthorizationView.as_view(), name="authorize"),
     path("token/", TokenView.as_view(), name="token"),
     path("introspect/", UUIDIntrospectTokenView.as_view(), name="introspect"),
+    path("productadmin/", ProductAdminView.as_view(), name="productadmin"),
     path("protected/", ProtectedViewSet.as_view(), name="protected"),
     path("labsprotected/", LabsProtectedViewSet.as_view(), name="labsprotected"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -213,8 +213,8 @@ class ProductAdminView(APIView):
                         user.is_staff = True
                         user.save()
                         continue
-
-                    permission_name = f"{permission_slug[:-6]} Admin"
+                    product_name = permission_slug[:-6].replace("_", " ").title()
+                    permission_name = f"{product_name} Admin"
                     permission, _ = Permission.objects.get_or_create(
                         content_type=content_type,
                         codename=permission_slug,

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,11 +1,14 @@
 import calendar
 import json
+from json.decoder import JSONDecodeError
 
 from django.contrib import auth
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Case, IntegerField, Q, Value, When
 from django.http import HttpResponseServerError
-from django.http.response import HttpResponse
+from django.http.response import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -13,6 +16,9 @@ from django.views.generic.base import View
 from oauth2_provider.models import get_access_token_model
 from oauth2_provider.views import IntrospectTokenView
 from rest_framework import generics
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_api_key.permissions import HasAPIKey
 from sentry_sdk import capture_message
 
 from accounts.auth import LabsView, PennView
@@ -172,3 +178,47 @@ class LabsProtectedViewSet(LabsView):
 
     def get(self, request, format=None):
         return HttpResponse({"secret_information": "this is a Penn Labs protected route"})
+
+
+class ProductAdminView(APIView):
+    """
+    Idempotently set admin permissions on all of our products.
+    Takes in a POST body in the form {"pennkey": ["permissions"]}
+    """
+
+    permission_classes = [HasAPIKey]
+
+    def post(self, request, format=None):
+        # Revoke all existing admin permissions
+        content_type = ContentType.objects.get(app_label="accounts", model="user")
+        perms = Permission.objects.filter(content_type=content_type, codename__endswith="_admin")
+        for perm in perms:
+            perm.user_set.clear()
+        User.objects.filter(Q(is_superuser=True) | Q(is_staff=True)).update(
+            is_superuser=False, is_staff=False
+        )
+
+        try:
+            body = json.loads(request.body)
+        except JSONDecodeError:
+            return HttpResponseBadRequest()
+
+        for pennkey in body:
+            user = User.objects.filter(username=pennkey).first()
+            if user is not None:
+                for permission_slug in body[pennkey]:
+                    # Handle platform separately
+                    if permission_slug == "platform_admin":
+                        user.is_superuser = True
+                        user.is_staff = True
+                        user.save()
+                        continue
+
+                    permission_name = f"{permission_slug[:-6]} Admin"
+                    permission, _ = Permission.objects.get_or_create(
+                        content_type=content_type,
+                        codename=permission_slug,
+                        defaults={"name": permission_name},
+                    )
+                    user.user_permissions.add(permission)
+        return Response({"detail": "success"})

--- a/tests/accounts/test_views.py
+++ b/tests/accounts/test_views.py
@@ -221,7 +221,7 @@ class ProductAdminViewTestCase(TestCase):
     def test_remove_product_admin(self):
         content_type = ContentType.objects.get(app_label="accounts", model="user")
         perm = Permission.objects.create(
-            content_type=content_type, codename="example_admin", name="Example Admin",
+            content_type=content_type, codename="example_admin", name="Example Admin"
         )
         self.user.user_permissions.add(perm)
         self.assertEqual(1, self.user.user_permissions.count())
@@ -253,7 +253,7 @@ class ProductAdminViewTestCase(TestCase):
     def test_add_product_admin(self):
         response = self.client.post(
             reverse("accounts:productadmin"),
-            {"test": ["example_admin"]},
+            {"test": ["example_product_admin"]},
             content_type="application/json",
             HTTP_AUTHORIZATION=self.authorization,
         )
@@ -261,8 +261,8 @@ class ProductAdminViewTestCase(TestCase):
         self.user.refresh_from_db()
         self.assertEqual(1, self.user.user_permissions.count())
         perm = self.user.user_permissions.first()
-        self.assertEqual("example_admin", perm.codename)
-        self.assertEqual("example Admin", perm.name)
+        self.assertEqual("example_product_admin", perm.codename)
+        self.assertEqual("Example Product Admin", perm.name)
 
     def test_add_platform_admin(self):
         response = self.client.post(


### PR DESCRIPTION
This PR creates an api-key-protected `ProducAdminView` that can update which users have admin access to our products (and platform itself) given a dictionary of users to admin permissions.

See pennlabs/infrastructure#72

[ch3268]