### PR TITLE
Allow Users to Register Client Credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 # IDE files
 .vscode/
 .idea/

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -4,6 +4,7 @@ from oauth2_provider.views import AuthorizationView, TokenView
 from rest_framework import routers
 
 from accounts.views import (
+    ApplicationViewSet,
     DevLoginView,
     DevLogoutView,
     EmailViewSet,
@@ -22,6 +23,7 @@ from accounts.views import (
 app_name = "accounts"
 
 router = routers.SimpleRouter()
+router.register("application", ApplicationViewSet, basename="application")
 router.register("me/phonenumber", PhoneNumberViewSet, basename="me-phonenumber")
 router.register("me/email", EmailViewSet, basename="me-email")
 router.register("majors", MajorViewSet, basename="majors")

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -29,6 +29,7 @@ from sentry_sdk import capture_message
 
 from accounts.models import Major, School, User
 from accounts.serializers import (
+    ApplicationSerializer,
     EmailSerializer,
     MajorSerializer,
     PhoneNumberSerializer,
@@ -121,6 +122,24 @@ class DevLogoutView(View):
     def get(self, request):
         auth.logout(request)
         return redirect("accounts:login")
+
+
+class ApplicationViewSet(viewsets.ModelViewSet):
+    """
+    A ViewSet for managing Applications, through which users can register
+    confidential client credentials to access API resources on their behalf
+    (e.g. for external developers writing automated scripts that access authenticated
+    Penn Labs routes, logged into their own Penn Labs account).
+    See ApplicationSerializer for an explanation of why we are not currently allowing
+    applications of other grant types (other than `client-credentials`).
+    """
+
+    serializer_class = ApplicationSerializer
+    lookup_field = "client_id"
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        return self.request.user.oauth2_provider_application.all()
 
 
 @method_decorator(csrf_exempt, name="dispatch")


### PR DESCRIPTION
This PR aims to add a developer page to https://platform.pennlabs.org/ where users can register client credentials for applications to access API resources on their behalf. This is useful for student developers who want to access authenticated routes on Penn Labs APIs, e.g. Penn Course Review routes.