### PR TITLE
Update emails on every login

### DIFF
--- a/backend/accounts/backends.py
+++ b/backend/accounts/backends.py
@@ -54,9 +54,13 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
         if email is None or email == "":
             email = f"{shibboleth_attributes['username']}@upenn.edu"
 
-        Email.objects.update_or_create(
-            user=user, value=email, primary=True, verified=True
-        )
+        old_email = Email.objects.filter(user=user, primary=True).first()
+
+        if old_email and old_email.value != email:
+            old_email.value = email
+            old_email.save()
+        elif not old_email:
+            Email.objects.create(user=user, value=email, primary=True, verified=True)
 
         # Update fields if changed
         for key, value in shibboleth_attributes.items():

--- a/backend/accounts/backends.py
+++ b/backend/accounts/backends.py
@@ -42,14 +42,21 @@ class ShibbolethRemoteUserBackend(RemoteUserBackend):
         )
 
         # Add initial attributes on first log in
+
         if created:
-            email = self.get_email(remote_user)
-            if email is None or email == "":
-                email = f"{shibboleth_attributes['username']}@upenn.edu"
             user.set_unusable_password()
             user.save()
             user = self.configure_user(request, user)
-            Email.objects.create(user=user, value=email, primary=True, verified=True)
+
+        # Always update email
+
+        email = self.get_email(remote_user)
+        if email is None or email == "":
+            email = f"{shibboleth_attributes['username']}@upenn.edu"
+
+        Email.objects.update_or_create(
+            user=user, value=email, primary=True, verified=True
+        )
 
         # Update fields if changed
         for key, value in shibboleth_attributes.items():


### PR DESCRIPTION
Previously, emails would only be set on first login. Update this on every login to prevent the default case of @upenn.edu emails persisting.