### PR TITLE
Opt Clubs out of team sync-related permission deletions

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -515,7 +515,7 @@ class ProductAdminView(APIView):
         content_type = ContentType.objects.get(app_label="accounts", model="user")
         perms = Permission.objects.filter(
             content_type=content_type, codename__endswith="_admin"
-        )
+        ).exclude(codename="penn_clubs_admin")
         for perm in perms:
             perm.user_set.clear()
         User.objects.filter(Q(is_superuser=True) | Q(is_staff=True)).update(


### PR DESCRIPTION
Makes Clubs permission syncing an upsert that does not wipe manually-set permissions.

Team sync currently requires (to my understanding) Github team membership, which school administration doesn't have, so Clubs needs the ability to manually set superuser permissions on a permanent basis. This is ideally a temporary change until team sync no longer requires Github team membership.

(Note: not sure how to test locally)