### PR TITLE
Updated healthcheck (/health)

### DIFF
--- a/backend/Platform/urls.py
+++ b/backend/Platform/urls.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import TemplateView
-from health.views import HealthView
 from rest_framework.schemas import get_schema_view
 
 
@@ -14,8 +13,7 @@ urlpatterns = [
     path("accounts/", include("accounts.urls", namespace="oauth2_provider")),
     path("options/", include("options.urls", namespace="options")),
     path("identity/", include("identity.urls", namespace="identity")),
-    path("health/", HealthView.as_view(), name="health"),
-    path("healthcheck/", include("health.urls", namespace="healthcheck")),
+    path("health/", include("health.urls", namespace="health")),
     path("s/", include("shortener.urls", namespace="shortener")),
     path(
         "openapi/",

--- a/backend/Platform/urls.py
+++ b/backend/Platform/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import TemplateView
+from health.views import HealthView
 from rest_framework.schemas import get_schema_view
 
 
@@ -13,6 +14,7 @@ urlpatterns = [
     path("accounts/", include("accounts.urls", namespace="oauth2_provider")),
     path("options/", include("options.urls", namespace="options")),
     path("identity/", include("identity.urls", namespace="identity")),
+    path("health/", HealthView.as_view(), name="health"),
     path("healthcheck/", include("health.urls", namespace="healthcheck")),
     path("s/", include("shortener.urls", namespace="shortener")),
     path(

--- a/backend/health/__init__.py
+++ b/backend/health/__init__.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class HealthConfig(AppConfig):
-    name = "health"

--- a/backend/health/urls.py
+++ b/backend/health/urls.py
@@ -5,5 +5,5 @@ from health.views import HealthView
 app_name = "health"
 
 urlpatterns = [
-    path("backend/", HealthView.as_view(), name="backend"),
+    path("", HealthView.as_view(), name="health"),
 ]

--- a/backend/tests/identity/test_views.py
+++ b/backend/tests/identity/test_views.py
@@ -190,3 +190,9 @@ class HealthTestCase(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"message": "OK"})
+
+    def test_health_shortcut(self):
+        url = reverse("health")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"message": "OK"})

--- a/backend/tests/identity/test_views.py
+++ b/backend/tests/identity/test_views.py
@@ -186,13 +186,7 @@ class HealthTestCase(TestCase):
         self.client = Client()
 
     def test_health(self):
-        url = reverse("healthcheck:backend")
-        resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json(), {"message": "OK"})
-
-    def test_health_shortcut(self):
-        url = reverse("health")
+        url = reverse("health:health")
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"message": "OK"})

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -49,7 +49,6 @@ export class MyChart extends PennLabsChart {
           "/documentation",
           "/Shibboleth.sso",
           "/health",
-          "/healthcheck",
         ],
         isSubdomain: true,
       }],

--- a/k8s/main.ts
+++ b/k8s/main.ts
@@ -48,6 +48,7 @@ export class MyChart extends PennLabsChart {
           "/openapi",
           "/documentation",
           "/Shibboleth.sso",
+          "/health",
           "/healthcheck",
         ],
         isSubdomain: true,


### PR DESCRIPTION
Motivation:
http://platform.pennlabs.org/healthcheck/backend doesn't work but https://platform-dev.pennlabs.org/healthcheck/backend/ does. 

This PR adds a http://platform.pennlabs.org/health path and removes the old healthcheck in an attempt to fix this working in prod.